### PR TITLE
Handle single baseline case

### DIFF
--- a/integration/test.ats
+++ b/integration/test.ats
@@ -35,6 +35,9 @@ serac_repo_dir = os.environ.get("ATS_SERAC_REPO_DIR")
 serac_baseline = os.environ.get("ATS_SERAC_BASELINE")
 if "," in serac_baseline:
     serac_baseline = serac_baseline.split(",")
+elif serac_baseline != "none" and serac_baseline != "all":
+    # Put baseline in List if single baseline
+    serac_baseline = [serac_baseline]
 
 #
 # Add variables to be used in individually sourced test files with define()


### PR DESCRIPTION
`./ats.sh -b dyn_solve_serial`

If you supply only one baseline to ats, the following error will occur:


```
Warning: Could not find test "d" to baseline.
Warning: Could not find test "y" to baseline.
Warning: Could not find test "n" to baseline.
Warning: Could not find test "_" to baseline.
Warning: Could not find test "s" to baseline.
Warning: Could not find test "o" to baseline.
Warning: Could not find test "l" to baseline.
Warning: Could not find test "v" to baseline.
Warning: Could not find test "e" to baseline.
Warning: Could not find test "_" to baseline.
Warning: Could not find test "s" to baseline.
Warning: Could not find test "e" to baseline.
Warning: Could not find test "r" to baseline.
Warning: Could not find test "i" to baseline.
Warning: Could not find test "a" to baseline.
Warning: Could not find test "l" to baseline.
```

The PR resolves the error by putting the single baseline in a List. Thank you @tupek2 for catching this. I will be creating a follow up PR in Serac itself updating this submodule, better documenting how to rebaseline integrations tests, and resolving the issue where `.cali` files are being moved here if you've built Serac with profiling enabled.